### PR TITLE
Manually add tag after npm package is published

### DIFF
--- a/dist/npm.js
+++ b/dist/npm.js
@@ -19892,12 +19892,13 @@ function publish_default(context, config, inDir) {
       } else {
         context.logger.error(`Version ${packageJson.version} has already been published to NPM`);
       }
+      const aliasTags = [];
       if (((_b = config.aliasTags) == null ? void 0 : _b[packageTag]) != null) {
         const aliasTagOrTags = config.aliasTags[packageTag];
-        const aliasTags = typeof aliasTagOrTags === "string" ? [aliasTagOrTags] : aliasTagOrTags;
-        for (const tag of aliasTags) {
-          yield npmAddTag(context, `${packageJson.name}@${packageJson.version}`, tag, npmRegistry, inDir);
-        }
+        aliasTags.push(...typeof aliasTagOrTags === "string" ? [aliasTagOrTags] : aliasTagOrTags);
+      }
+      for (const tag of [packageTag, ...aliasTags]) {
+        yield npmAddTag(context, `${packageJson.name}@${packageJson.version}`, tag, npmRegistry, inDir);
       }
     } finally {
       if (fs3.existsSync(".npmrc.bak")) {

--- a/packages/npm/src/publish.ts
+++ b/packages/npm/src/publish.ts
@@ -65,12 +65,13 @@ export default async function (context: IContext, config: IPluginConfig, inDir?:
         }
 
         // Add alias tags
+        const aliasTags: string[] = [];
         if (config.aliasTags?.[packageTag] != null) {
             const aliasTagOrTags = config.aliasTags[packageTag];
-            const aliasTags: string[] = (typeof aliasTagOrTags === "string") ? [aliasTagOrTags] : aliasTagOrTags;
-            for (const tag of aliasTags) {
-                await utils.npmAddTag(context, `${packageJson.name}@${packageJson.version}`, tag, npmRegistry, inDir);
-            }
+            aliasTags.push(...(typeof aliasTagOrTags === "string" ? [aliasTagOrTags] : aliasTagOrTags));
+        }
+        for (const tag of [packageTag, ...aliasTags]) {
+            await utils.npmAddTag(context, `${packageJson.name}@${packageJson.version}`, tag, npmRegistry, inDir);
         }
     } finally {
         if (fs.existsSync(".npmrc.bak")) {


### PR DESCRIPTION
In theory this shouldn't be necessary, but we've observed a bug with Artifactory where the `@latest` tag sometimes fails to update.