### PR TITLE
Add released label only to PRs that publish new packages

### DIFF
--- a/dist/github.js
+++ b/dist/github.js
@@ -42789,6 +42789,9 @@ function uploadAssets(context, octokit, release, assetPaths) {
 var import_core3 = __toESM(require_lib5());
 function success_default(context, config) {
   return __async(this, null, function* () {
+    if (Object.keys(context.releasedPackages).length == 0) {
+      return;
+    }
     const octokit = getOctokit2(context, config);
     const prs = yield octokit.repos.listPullRequestsAssociatedWithCommit(__spreadProps(__spreadValues({}, context.ci.repo), {
       commit_sha: context.ci.commit
@@ -42800,26 +42803,24 @@ function success_default(context, config) {
           labels: ["released"]
         }));
       }));
-      if (Object.keys(context.releasedPackages).length > 0) {
-        const packageList = [];
-        for (const pkgType of Object.keys(context.releasedPackages)) {
-          for (const { name, url } of context.releasedPackages[pkgType]) {
-            const pkgName = url != null ? `[${name}](${url})` : `\`${name}\``;
-            packageList.push(`**${pkgType}**: ${pkgName}`);
-          }
+      const packageList = [];
+      for (const pkgType of Object.keys(context.releasedPackages)) {
+        for (const { name, url } of context.releasedPackages[pkgType]) {
+          const pkgName = url != null ? `[${name}](${url})` : `\`${name}\``;
+          packageList.push(`**${pkgType}**: ${pkgName}`);
         }
-        yield import_core3.utils.dryRunTask(context, "create success comment on pull request", () => __async(this, null, function* () {
-          yield octokit.issues.createComment(__spreadProps(__spreadValues({}, context.ci.repo), {
-            issue_number: prs.data[0].number,
-            body: `Release succeeded for the \`${context.branch.name}\` branch. :tada:
+      }
+      yield import_core3.utils.dryRunTask(context, "create success comment on pull request", () => __async(this, null, function* () {
+        yield octokit.issues.createComment(__spreadProps(__spreadValues({}, context.ci.repo), {
+          issue_number: prs.data[0].number,
+          body: `Release succeeded for the \`${context.branch.name}\` branch. :tada:
 
 The following packages have been published:
 ` + packageList.map((line) => `* ${line}`).join("\n") + `
 
 <sub>Powered by Octorelease :rocket:</sub>`
-          }));
         }));
-      }
+      }));
     }
   });
 }

--- a/dist/github.js
+++ b/dist/github.js
@@ -42789,39 +42789,40 @@ function uploadAssets(context, octokit, release, assetPaths) {
 var import_core3 = __toESM(require_lib5());
 function success_default(context, config) {
   return __async(this, null, function* () {
-    if (Object.keys(context.releasedPackages).length == 0) {
+    if (Object.keys(context.releasedPackages).length === 0) {
       return;
     }
     const octokit = getOctokit2(context, config);
     const prs = yield octokit.repos.listPullRequestsAssociatedWithCommit(__spreadProps(__spreadValues({}, context.ci.repo), {
       commit_sha: context.ci.commit
     }));
-    if (prs.data.length > 0) {
-      yield import_core3.utils.dryRunTask(context, "add released label to pull request", () => __async(this, null, function* () {
-        yield octokit.issues.addLabels(__spreadProps(__spreadValues({}, context.ci.repo), {
-          issue_number: prs.data[0].number,
-          labels: ["released"]
-        }));
+    if (prs.data.length === 0) {
+      return;
+    }
+    yield import_core3.utils.dryRunTask(context, "add released label to pull request", () => __async(this, null, function* () {
+      yield octokit.issues.addLabels(__spreadProps(__spreadValues({}, context.ci.repo), {
+        issue_number: prs.data[0].number,
+        labels: ["released"]
       }));
-      const packageList = [];
-      for (const pkgType of Object.keys(context.releasedPackages)) {
-        for (const { name, url } of context.releasedPackages[pkgType]) {
-          const pkgName = url != null ? `[${name}](${url})` : `\`${name}\``;
-          packageList.push(`**${pkgType}**: ${pkgName}`);
-        }
+    }));
+    const packageList = [];
+    for (const pkgType of Object.keys(context.releasedPackages)) {
+      for (const { name, url } of context.releasedPackages[pkgType]) {
+        const pkgName = url != null ? `[${name}](${url})` : `\`${name}\``;
+        packageList.push(`**${pkgType}**: ${pkgName}`);
       }
-      yield import_core3.utils.dryRunTask(context, "create success comment on pull request", () => __async(this, null, function* () {
-        yield octokit.issues.createComment(__spreadProps(__spreadValues({}, context.ci.repo), {
-          issue_number: prs.data[0].number,
-          body: `Release succeeded for the \`${context.branch.name}\` branch. :tada:
+    }
+    yield import_core3.utils.dryRunTask(context, "create success comment on pull request", () => __async(this, null, function* () {
+      yield octokit.issues.createComment(__spreadProps(__spreadValues({}, context.ci.repo), {
+        issue_number: prs.data[0].number,
+        body: `Release succeeded for the \`${context.branch.name}\` branch. :tada:
 
 The following packages have been published:
 ` + packageList.map((line) => `* ${line}`).join("\n") + `
 
 <sub>Powered by Octorelease :rocket:</sub>`
-        }));
       }));
-    }
+    }));
   });
 }
 
@@ -42829,26 +42830,28 @@ The following packages have been published:
 var import_core4 = __toESM(require_lib5());
 function fail_default(context, config) {
   return __async(this, null, function* () {
-    if (config.checkPrLabels) {
-      const octokit = getOctokit2(context, config);
-      const prs = yield octokit.repos.listPullRequestsAssociatedWithCommit(__spreadProps(__spreadValues({}, context.ci.repo), {
-        commit_sha: context.ci.commit
-      }));
-      if (prs.data.length > 0) {
-        const prNumber = prs.data[0].number;
-        const labels = yield octokit.issues.listLabelsOnIssue(__spreadProps(__spreadValues({}, context.ci.repo), {
-          issue_number: prNumber
+    if (!config.checkPrLabels) {
+      return;
+    }
+    const octokit = getOctokit2(context, config);
+    const prs = yield octokit.repos.listPullRequestsAssociatedWithCommit(__spreadProps(__spreadValues({}, context.ci.repo), {
+      commit_sha: context.ci.commit
+    }));
+    if (prs.data.length === 0) {
+      return;
+    }
+    const prNumber = prs.data[0].number;
+    const labels = yield octokit.issues.listLabelsOnIssue(__spreadProps(__spreadValues({}, context.ci.repo), {
+      issue_number: prNumber
+    }));
+    const releaseLabels = Array.isArray(config.checkPrLabels) ? config.checkPrLabels : DEFAULT_RELEASE_LABELS;
+    for (const { name } of labels.data.filter((label) => releaseLabels.includes(label.name))) {
+      yield import_core4.utils.dryRunTask(context, `remove pull request label "${name}"`, () => __async(this, null, function* () {
+        yield octokit.issues.removeLabel(__spreadProps(__spreadValues({}, context.ci.repo), {
+          issue_number: prNumber,
+          name
         }));
-        const releaseLabels = Array.isArray(config.checkPrLabels) ? config.checkPrLabels : DEFAULT_RELEASE_LABELS;
-        for (const { name } of labels.data.filter((label) => releaseLabels.includes(label.name))) {
-          yield import_core4.utils.dryRunTask(context, `remove pull request label "${name}"`, () => __async(this, null, function* () {
-            yield octokit.issues.removeLabel(__spreadProps(__spreadValues({}, context.ci.repo), {
-              issue_number: prNumber,
-              name
-            }));
-          }));
-        }
-      }
+      }));
     }
   });
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -186,7 +186,7 @@ async function loadCiEnv(): Promise<any> {
         const cmdOutput = await exec.getExecOutput("git", ["config", "--get", "remote.origin.url"]);
         envCi.slug = cmdOutput.stdout.trim().replace(/\.git$/, "").split("/").slice(-2).join("/");
     }
-    const [ owner, repo ] = envCi.slug.split("/");
+    const [owner, repo] = envCi.slug.split("/");
 
     return { ...envCi, repo: { owner, repo } };
 }

--- a/packages/github/src/fail.ts
+++ b/packages/github/src/fail.ts
@@ -19,30 +19,33 @@ import { DEFAULT_RELEASE_LABELS, IPluginConfig } from "./config";
 import { getOctokit } from "./utils";
 
 export default async function (context: IContext, config: IPluginConfig): Promise<void> {
-    if (config.checkPrLabels) {
-        const octokit = getOctokit(context, config);
-        const prs = await octokit.repos.listPullRequestsAssociatedWithCommit({
-            ...context.ci.repo,
-            commit_sha: context.ci.commit
-        });
+    if (!config.checkPrLabels) {
+        return;
+    }
 
-        if (prs.data.length > 0) {
-            const prNumber = prs.data[0].number;
-            const labels = await octokit.issues.listLabelsOnIssue({
+    const octokit = getOctokit(context, config);
+    const prs = await octokit.repos.listPullRequestsAssociatedWithCommit({
+        ...context.ci.repo,
+        commit_sha: context.ci.commit
+    });
+    if (prs.data.length === 0) {
+        return;
+    }
+
+    const prNumber = prs.data[0].number;
+    const labels = await octokit.issues.listLabelsOnIssue({
+        ...context.ci.repo,
+        issue_number: prNumber
+    });
+    const releaseLabels = Array.isArray(config.checkPrLabels) ? config.checkPrLabels : DEFAULT_RELEASE_LABELS;
+
+    for (const { name } of labels.data.filter(label => releaseLabels.includes(label.name))) {
+        await utils.dryRunTask(context, `remove pull request label "${name}"`, async () => {
+            await octokit.issues.removeLabel({
                 ...context.ci.repo,
-                issue_number: prNumber
+                issue_number: prNumber,
+                name
             });
-            const releaseLabels = Array.isArray(config.checkPrLabels) ? config.checkPrLabels : DEFAULT_RELEASE_LABELS;
-
-            for (const { name } of labels.data.filter(label => releaseLabels.includes(label.name))) {
-                await utils.dryRunTask(context, `remove pull request label "${name}"`, async () => {
-                    await octokit.issues.removeLabel({
-                        ...context.ci.repo,
-                        issue_number: prNumber,
-                        name
-                    });
-                });
-            }
-        }
+        });
     }
 }

--- a/packages/github/src/success.ts
+++ b/packages/github/src/success.ts
@@ -19,7 +19,7 @@ import { IPluginConfig } from "./config";
 import * as utils from "./utils";
 
 export default async function (context: IContext, config: IPluginConfig): Promise<void> {
-    if (Object.keys(context.releasedPackages).length == 0) {
+    if (Object.keys(context.releasedPackages).length === 0) {
         return;
     }
 
@@ -28,32 +28,33 @@ export default async function (context: IContext, config: IPluginConfig): Promis
         ...context.ci.repo,
         commit_sha: context.ci.commit
     });
+    if (prs.data.length === 0) {
+        return;
+    }
 
-    if (prs.data.length > 0) {
-        await coreUtils.dryRunTask(context, "add released label to pull request", async () => {
-            await octokit.issues.addLabels({
-                ...context.ci.repo,
-                issue_number: prs.data[0].number,
-                labels: ["released"]
-            });
+    await coreUtils.dryRunTask(context, "add released label to pull request", async () => {
+        await octokit.issues.addLabels({
+            ...context.ci.repo,
+            issue_number: prs.data[0].number,
+            labels: ["released"]
         });
+    });
 
-        const packageList: string[] = [];
-        for (const pkgType of Object.keys(context.releasedPackages)) {
-            for (const { name, url } of context.releasedPackages[pkgType]) {
-                const pkgName = url != null ? `[${name}](${url})` : `\`${name}\``;
-                packageList.push(`**${pkgType}**: ${pkgName}`);
-            }
+    const packageList: string[] = [];
+    for (const pkgType of Object.keys(context.releasedPackages)) {
+        for (const { name, url } of context.releasedPackages[pkgType]) {
+            const pkgName = url != null ? `[${name}](${url})` : `\`${name}\``;
+            packageList.push(`**${pkgType}**: ${pkgName}`);
         }
-        await coreUtils.dryRunTask(context, "create success comment on pull request", async () => {
-            await octokit.issues.createComment({
-                ...context.ci.repo,
-                issue_number: prs.data[0].number,
-                body: `Release succeeded for the \`${context.branch.name}\` branch. :tada:\n\n` +
+    }
+    await coreUtils.dryRunTask(context, "create success comment on pull request", async () => {
+        await octokit.issues.createComment({
+            ...context.ci.repo,
+            issue_number: prs.data[0].number,
+            body: `Release succeeded for the \`${context.branch.name}\` branch. :tada:\n\n` +
                 `The following packages have been published:\n` +
                 packageList.map(line => `* ${line}`).join("\n") + `\n\n` +
                 `<sub>Powered by Octorelease :rocket:</sub>`
-            });
         });
-    }
+    });
 }


### PR DESCRIPTION
This makes the "released" label more meaningful, instead of being clutter that shows up on every PR like it does now:
![image](https://user-images.githubusercontent.com/22344007/204895962-39f0909b-b9e7-411a-883b-2d165d3046a9.png)