### PR TITLE
Fix release labels not detected on PRs

### DIFF
--- a/dist/github.js
+++ b/dist/github.js
@@ -24116,16 +24116,17 @@ var DEFAULT_RELEASE_LABELS = ["release-current", "release-patch", "release-minor
 // src/utils.ts
 var utils_exports = {};
 __export(utils_exports, {
-  asyncFilter: () => asyncFilter,
+  filterAsync: () => filterAsync,
   getOctokit: () => getOctokit2
 });
 var github = __toESM(require_github());
 var import_utils = __toESM(require_utils3());
 var import_plugin_enterprise_server = __toESM(require_dist_node11());
-function asyncFilter(array, predicate) {
-  return array.reduce((result, current, index) => __async(this, null, function* () {
-    return (yield predicate(current, index)) ? [...yield result, current] : result;
-  }), Promise.resolve([]));
+function filterAsync(array, predicate) {
+  return __async(this, null, function* () {
+    const filterMap = yield Promise.all(array.map(predicate));
+    return array.filter((_value, index) => filterMap[index]);
+  });
 }
 function getOctokit2(context, config) {
   if (config.githubUrl != null) {
@@ -24236,7 +24237,7 @@ function findApprovedLabelEvents(context, octokit, prNumber, releaseLabels) {
       headers: lastEtag ? { "if-none-match": lastEtag } : void 0
     }));
     lastEtag = events.headers.etag;
-    return asyncFilter(events.data, (current, index) => __async(this, null, function* () {
+    return filterAsync(events.data, (current, index) => __async(this, null, function* () {
       const futureEvents = events.data.slice(index + 1);
       if (current.event !== "labeled") {
         return false;

--- a/packages/github/src/init.ts
+++ b/packages/github/src/init.ts
@@ -20,6 +20,8 @@ import { IContext, Inputs } from "@octorelease/core";
 import { DEFAULT_RELEASE_LABELS, IPluginConfig } from "./config";
 import * as utils from "./utils";
 
+let lastEtag: string | undefined;
+
 export default async function (context: IContext, config: IPluginConfig): Promise<void> {
     if (context.env.GITHUB_TOKEN == null) {
         throw new Error("Required environment variable GITHUB_TOKEN is undefined");
@@ -50,19 +52,13 @@ async function getPrReleaseType(context: IContext, config: IPluginConfig): Promi
         issue_number: prNumber
     });
 
-    if (labels.data.findIndex(label => label.name === "released") !== -1) {
+    if (labels.data.some(label => label.name === "released")) {
         context.logger.warn("Pull request already released, no new version detected");
         return null;
     }
 
-    const events = await octokit.rest.issues.listEvents({
-        ...context.ci.repo,
-        issue_number: prNumber,
-        per_page: 100
-    });
-    const collaborators = await octokit.rest.repos.listCollaborators(context.ci.repo);
     const releaseLabels = Array.isArray(config.checkPrLabels) ? config.checkPrLabels : DEFAULT_RELEASE_LABELS;
-    let approvedLabelEvents = findApprovedLabelEvents(events.data, collaborators.data, releaseLabels);
+    let approvedLabelEvents = await findApprovedLabelEvents(context, octokit, prNumber, releaseLabels);
 
     if (approvedLabelEvents.length !== 1 && !context.dryRun) {
         const timeoutInMinutes = 30;
@@ -100,19 +96,11 @@ async function getPrReleaseType(context: IContext, config: IPluginConfig): Promi
         context.logger.info("Waiting for repo admin to add release label to pull request...");
         const startTime = new Date().getTime();
         const timeoutInMsec = timeoutInMinutes * 60000;
-        let lastEtag = events.headers.etag;
         while (approvedLabelEvents.length !== 1 && (new Date().getTime() - startTime) < timeoutInMsec) {
             await delay(1000);
 
             try {
-                const response = await octokit.rest.issues.listEvents({
-                    ...context.ci.repo,
-                    issue_number: prNumber,
-                    per_page: 100,
-                    headers: { "if-none-match": lastEtag }
-                });
-                approvedLabelEvents = findApprovedLabelEvents(response.data, collaborators.data, releaseLabels);
-                lastEtag = response.headers.etag;
+                approvedLabelEvents = await findApprovedLabelEvents(context, octokit, prNumber, releaseLabels);
             } catch (error) {
                 if (!(error instanceof RequestError && error.status === 304)) {
                     throw error;
@@ -141,27 +129,38 @@ async function getPrReleaseType(context: IContext, config: IPluginConfig): Promi
     return null;
 }
 
-function findApprovedLabelEvents(events: any[], collaborators: any[], releaseLabels: string[]): any[] {
+async function findApprovedLabelEvents(context: IContext, octokit: utils.Octokit, prNumber: number,
+    releaseLabels: string[]): Promise<Record<string, any>[]> {
+    const getCollaboratorPermissionLevel = (username: string) =>
+        octokit.rest.repos.getCollaboratorPermissionLevel({ ...context.ci.repo, username });
+    const events = await octokit.rest.issues.listEvents({
+        ...context.ci.repo,
+        issue_number: prNumber,
+        per_page: 100,
+        headers: lastEtag ? { "if-none-match": lastEtag } : undefined
+    });
+    lastEtag = events.headers.etag;
+
     /**
      * Filter to remove the following:
      *  - Other kinds of events besides label creation
+     *  - Non-release labels with names we don't care about
      *  - Labels that were added before the PR was merged
      *  - Labels that were temporarily added and later removed
      *  - Labels that were added by user without admin privileges
-     *  - Non-release labels with names we don't care about
      */
-    return events.filter((event, idx) => {
-        const futureEvents = events.slice(idx + 1);
+    return utils.asyncFilter(events.data, async (current: any, index: number) => {
+        const futureEvents: any[] = events.data.slice(index + 1);
 
-        if (event.event !== "labeled") {
+        if (current.event !== "labeled") {
             return false;
-        } else if (futureEvents.findIndex(e => e.event === "merged") !== -1) {
+        } else if (!releaseLabels.includes(current.label.name)) {
             return false;
-        } else if (futureEvents.findIndex(e => e.event === "unlabeled" && e.label.name === event.label.name) !== -1) {
+        } else if (futureEvents.some(e => e.event === "merged")) {
             return false;
-        } else if (collaborators.findIndex(user => user.id === event.actor.id && user.permissions?.admin) === -1) {
+        } else if (futureEvents.some(e => e.event === "unlabeled" && e.label.name === current.label.name)) {
             return false;
-        } else if (!releaseLabels.includes(event.label.name)) {
+        } else if ((await getCollaboratorPermissionLevel(current.actor.login)).data.permission !== "admin") {
             return false;
         }
 

--- a/packages/github/src/init.ts
+++ b/packages/github/src/init.ts
@@ -149,7 +149,7 @@ async function findApprovedLabelEvents(context: IContext, octokit: utils.Octokit
      *  - Labels that were temporarily added and later removed
      *  - Labels that were added by user without admin privileges
      */
-    return utils.asyncFilter(events.data, async (current: any, index: number) => {
+    return utils.filterAsync(events.data, async (current: any, index: number) => {
         const futureEvents: any[] = events.data.slice(index + 1);
 
         if (current.event !== "labeled") {

--- a/packages/github/src/publish.ts
+++ b/packages/github/src/publish.ts
@@ -22,8 +22,6 @@ import { IContext, utils as coreUtils } from "@octorelease/core";
 import { IPluginConfig } from "./config";
 import * as utils from "./utils";
 
-type Octokit = ReturnType<typeof utils.getOctokit>;
-
 export default async function (context: IContext, config: IPluginConfig): Promise<void> {
     if (!config.publishRelease && !config.assets) {
         return;
@@ -47,7 +45,7 @@ export default async function (context: IContext, config: IPluginConfig): Promis
     }
 }
 
-async function createRelease(context: IContext, octokit: Octokit): Promise<any> {
+async function createRelease(context: IContext, octokit: utils.Octokit): Promise<Record<string, any>> {
     const tagName = context.tagPrefix + context.version.new;
     let release: any;
 
@@ -79,7 +77,8 @@ async function createRelease(context: IContext, octokit: Octokit): Promise<any> 
     return release;
 }
 
-async function uploadAssets(context: IContext, octokit: Octokit, release: any, assetPaths: string[]): Promise<void> {
+async function uploadAssets(context: IContext, octokit: utils.Octokit, release: Record<string, any>,
+    assetPaths: string[]): Promise<void> {
     const globber = await glob.create(assetPaths.join("\n"));
     const artifactPaths: string[] = await globber.glob();
     const mime = require("mime-types");
@@ -88,7 +87,7 @@ async function uploadAssets(context: IContext, octokit: Octokit, release: any, a
         const assetName = path.basename(artifactPath);
 
         // Skip uploading asset if one with same name was uploaded previously
-        if (release.data.assets && release.data.assets.findIndex((asset: any) => asset.name === assetName) !== -1) {
+        if (release.data.assets && release.data.assets.some((asset: any) => asset.name === assetName)) {
             context.logger.error(`Release asset ${artifactPath} has already been uploaded to GitHub`);
             continue;
         }

--- a/packages/github/src/utils.ts
+++ b/packages/github/src/utils.ts
@@ -22,10 +22,11 @@ import { IPluginConfig } from "./config";
 
 export type Octokit = ReturnType<typeof github.getOctokit>;
 
-export function asyncFilter<T>(array: T[], predicate: (value: T, index: number) => Promise<boolean>): Promise<T[]> {
-    return array.reduce(async (result: Promise<T[]>, current: T, index: number) => {
-        return (await predicate(current, index)) ? [...await result, current] : result;
-    }, Promise.resolve([]));
+export async function filterAsync<T>(array: T[],
+    predicate: (value: T, index: number, array: T[]) => Promise<boolean>): Promise<T[]> {
+    // https://stackoverflow.com/questions/33355528
+    const filterMap = await Promise.all(array.map(predicate));
+    return array.filter((_value, index) => filterMap[index]);
 }
 
 export function getOctokit(context: IContext, config: IPluginConfig): Octokit {

--- a/packages/github/src/utils.ts
+++ b/packages/github/src/utils.ts
@@ -20,7 +20,15 @@ import { enterpriseServer37 } from "@octokit/plugin-enterprise-server";
 import { IContext } from "@octorelease/core";
 import { IPluginConfig } from "./config";
 
-export function getOctokit(context: IContext, config: IPluginConfig): InstanceType<typeof GitHub> {
+export type Octokit = ReturnType<typeof github.getOctokit>;
+
+export function asyncFilter<T>(array: T[], predicate: (value: T, index: number) => Promise<boolean>): Promise<T[]> {
+    return array.reduce(async (result: Promise<T[]>, current: T, index: number) => {
+        return (await predicate(current, index)) ? [...await result, current] : result;
+    }, Promise.resolve([]));
+}
+
+export function getOctokit(context: IContext, config: IPluginConfig): Octokit {
     if (config.githubUrl != null) {
         const octokit = GitHub.plugin(enterpriseServer37);
         const githubUrl = config.githubUrl.endsWith("/") ? config.githubUrl : (config.githubUrl + "/");


### PR DESCRIPTION
The default permissions for GITHUB_TOKEN are missing `read:org` which is required for the API to list repository collaborators:
> You must authenticate using an access token with the read:org and repo scopes with push access to use this endpoint.

Anyone who is a private member (which is default membership status) of the Zowe GitHub org will not be included in the list.

To work around this requirement, we can use the API to get repository permissions for a specific user, which works independent of org-related permissions and membership settings.

This should fix @traeok not having sufficient permission to tag https://github.com/zowe/zowe-cli/pull/1652 with "release-patch".

GitHub REST API docs: https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28