### PR TITLE
Bump versions to v1 and update changelogs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5761,18 +5761,18 @@
     },
     "packages/changelog": {
       "name": "@octorelease/changelog",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/glob": "^0.4.0"
       },
       "peerDependencies": {
-        "@octorelease/core": "^0.2.0"
+        "@octorelease/core": "^1.0.0"
       }
     },
     "packages/core": {
       "name": "@octorelease/core",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.3.0",
@@ -5787,10 +5787,10 @@
         "octorelease": "lib/main.js"
       },
       "optionalDependencies": {
-        "@octorelease/changelog": "^0.2.0",
-        "@octorelease/git": "^0.2.0",
-        "@octorelease/github": "^0.2.0",
-        "@octorelease/npm": "^0.2.0"
+        "@octorelease/changelog": "^1.0.0",
+        "@octorelease/git": "^1.0.0",
+        "@octorelease/github": "^1.0.0",
+        "@octorelease/npm": "^1.0.0"
       }
     },
     "packages/core/node_modules/semver": {
@@ -5803,18 +5803,18 @@
     },
     "packages/git": {
       "name": "@octorelease/git",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/exec": "^1.1.0"
       },
       "peerDependencies": {
-        "@octorelease/core": "^0.2.0"
+        "@octorelease/core": "^1.0.0"
       }
     },
     "packages/github": {
       "name": "@octorelease/github",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/github": "^5.1.0",
@@ -5826,7 +5826,7 @@
       },
       "peerDependencies": {
         "@octokit/request-error": "^2.1.0",
-        "@octorelease/core": "^0.2.0"
+        "@octorelease/core": "^1.0.0"
       }
     },
     "packages/github/node_modules/semver": {
@@ -5839,20 +5839,20 @@
     },
     "packages/lerna": {
       "name": "@octorelease/lerna",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/exec": "^1.1.0",
-        "@octorelease/npm": "^0.2.0",
+        "@octorelease/npm": "^1.0.0",
         "find-up": "^5.0.0"
       },
       "peerDependencies": {
-        "@octorelease/core": "^0.2.0"
+        "@octorelease/core": "^1.0.0"
       }
     },
     "packages/npm": {
       "name": "@octorelease/npm",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/exec": "^1.1.0",
@@ -5860,21 +5860,21 @@
         "find-up": "^5.0.0"
       },
       "peerDependencies": {
-        "@octorelease/core": "^0.2.0"
+        "@octorelease/core": "^1.0.0"
       }
     },
     "packages/run-script": {
       "name": "@octorelease/run-script",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.8.2",
         "@actions/exec": "^1.1.0",
         "@actions/github": "^5.0.3",
-        "@octorelease/core": "^0.2.0",
-        "@octorelease/git": "^0.2.0",
-        "@octorelease/lerna": "^0.2.0",
-        "@octorelease/npm": "^0.2.0",
+        "@octorelease/core": "^1.0.0",
+        "@octorelease/git": "^1.0.0",
+        "@octorelease/lerna": "^1.0.0",
+        "@octorelease/npm": "^1.0.0",
         "adm-zip": "^0.5.10",
         "java-properties": "^1.0.2",
         "pluralize": "^8.0.0",
@@ -5891,13 +5891,13 @@
     },
     "packages/vsce": {
       "name": "@octorelease/vsce",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/exec": "^1.1.0"
       },
       "peerDependencies": {
-        "@octorelease/core": "^0.2.0"
+        "@octorelease/core": "^1.0.0"
       }
     }
   },
@@ -7202,10 +7202,10 @@
       "requires": {
         "@actions/core": "^1.3.0",
         "@actions/exec": "^1.1.0",
-        "@octorelease/changelog": "^0.2.0",
-        "@octorelease/git": "^0.2.0",
-        "@octorelease/github": "^0.2.0",
-        "@octorelease/npm": "^0.2.0",
+        "@octorelease/changelog": "^1.0.0",
+        "@octorelease/git": "^1.0.0",
+        "@octorelease/github": "^1.0.0",
+        "@octorelease/npm": "^1.0.0",
         "@types/env-ci": "^3.1.1",
         "cosmiconfig": "^7.0.0",
         "env-ci": "^5.4.0",
@@ -7248,7 +7248,7 @@
       "version": "file:packages/lerna",
       "requires": {
         "@actions/exec": "^1.1.0",
-        "@octorelease/npm": "^0.2.0",
+        "@octorelease/npm": "^1.0.0",
         "find-up": "^5.0.0"
       }
     },
@@ -7266,10 +7266,10 @@
         "@actions/core": "^1.8.2",
         "@actions/exec": "^1.1.0",
         "@actions/github": "^5.0.3",
-        "@octorelease/core": "^0.2.0",
-        "@octorelease/git": "^0.2.0",
-        "@octorelease/lerna": "^0.2.0",
-        "@octorelease/npm": "^0.2.0",
+        "@octorelease/core": "^1.0.0",
+        "@octorelease/git": "^1.0.0",
+        "@octorelease/lerna": "^1.0.0",
+        "@octorelease/npm": "^1.0.0",
         "adm-zip": "^0.5.10",
         "java-properties": "^1.0.2",
         "pluralize": "^8.0.0",

--- a/packages/changelog/CHANGELOG.md
+++ b/packages/changelog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## `1.0.0`
+
+* First stable release
+
 ## `0.2.0`
 
 * Support `displayNames` option that defines display names for packages in a monorepo (e.g., "zowe-explorer-ftp-extension" -> "Zowe Explorer Extension for FTP")

--- a/packages/changelog/package.json
+++ b/packages/changelog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octorelease/changelog",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Octorelease plugin to read and update changelogs.",
   "main": "lib/index.js",
   "files": [
@@ -38,6 +38,6 @@
     "@actions/glob": "^0.4.0"
   },
   "peerDependencies": {
-    "@octorelease/core": "^0.2.0"
+    "@octorelease/core": "^1.0.0"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## `1.0.0`
+
+* Include unannotated tags in check for old version
+* Automatically detect log prefix from call stack
+* Create `IContextOpts` interface for options passed to `buildContext` method
+
 ## `0.2.0`
 
 * Added support for more than one config object per plugin in release config

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octorelease/core",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Octorelease core package containing the CLI and APIs for plugins.",
   "main": "lib/index.js",
   "bin": {
@@ -53,9 +53,9 @@
     "semver": "^6.3.0"
   },
   "optionalDependencies": {
-    "@octorelease/changelog": "^0.2.0",
-    "@octorelease/git": "^0.2.0",
-    "@octorelease/github": "^0.2.0",
-    "@octorelease/npm": "^0.2.0"
+    "@octorelease/changelog": "^1.0.0",
+    "@octorelease/git": "^1.0.0",
+    "@octorelease/github": "^1.0.0",
+    "@octorelease/npm": "^1.0.0"
   }
 }

--- a/packages/git/CHANGELOG.md
+++ b/packages/git/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## Recent Changes
+## `1.0.0`
 
 * License project under Apache-2.0
+* Validate Git credentials before releasing
+* Fix duplicate ci skip in commit message
+* Support inclusive "or" to push Git branches/tags
 
 ## `0.0.1`
 

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octorelease/git",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Octorelease plugin to perform actions on a Git repository.",
   "main": "lib/index.js",
   "files": [
@@ -38,6 +38,6 @@
     "@actions/exec": "^1.1.0"
   },
   "peerDependencies": {
-    "@octorelease/core": "^0.2.0"
+    "@octorelease/core": "^1.0.0"
   }
 }

--- a/packages/github/CHANGELOG.md
+++ b/packages/github/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## `1.0.0`
+
+* Fix release labels not detected on PRs
+* Look for release labels only on merged PRs
+
 ## `0.2.0`
 
 * [BREAKING] Create new releases in draft status

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octorelease/github",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Octorelease plugin to perform actions related to GitHub.",
   "main": "lib/index.js",
   "files": [
@@ -44,6 +44,6 @@
   },
   "peerDependencies": {
     "@octokit/request-error": "^2.1.0",
-    "@octorelease/core": "^0.2.0"
+    "@octorelease/core": "^1.0.0"
   }
 }

--- a/packages/lerna/CHANGELOG.md
+++ b/packages/lerna/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## `1.0.0`
+
+* First stable release
+
 ## `0.1.1`
 
 * Fixed init stage not detecting publish registry configured in lerna.json

--- a/packages/lerna/package.json
+++ b/packages/lerna/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octorelease/lerna",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Octorelease plugin to perform actions related to NPM for Lerna monorepo.",
   "main": "lib/index.js",
   "files": [
@@ -38,10 +38,10 @@
   },
   "dependencies": {
     "@actions/exec": "^1.1.0",
-    "@octorelease/npm": "^0.2.0",
+    "@octorelease/npm": "^1.0.0",
     "find-up": "^5.0.0"
   },
   "peerDependencies": {
-    "@octorelease/core": "^0.2.0"
+    "@octorelease/core": "^1.0.0"
   }
 }

--- a/packages/npm/CHANGELOG.md
+++ b/packages/npm/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## `1.0.0`
+
+* Move project .npmrc out of the way for publish
+* Manually add tag after npm package is published
+* Fix npm pack failing to return tgz filename
+* Add `pruneShrinkwrap` option to prune dev and extraneous dependencies from npm-shrinkwrap.json
+* Skip npm version in workspaces to avoid conflicts with lerna plugin
+
 ## `0.1.0`
 
 * Fixed init stage logging in to npm when `npmPublish` is false

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octorelease/npm",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Octorelease plugin to perform actions related to NPM.",
   "main": "lib/index.js",
   "files": [
@@ -41,6 +41,6 @@
     "find-up": "^5.0.0"
   },
   "peerDependencies": {
-    "@octorelease/core": "^0.2.0"
+    "@octorelease/core": "^1.0.0"
   }
 }

--- a/packages/run-script/CHANGELOG.md
+++ b/packages/run-script/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
-## Recent Changes
+## `1.0.0`
+
+* Add prepareRelease script
+* Look for release labels only on merged PRs that target the current branch
+
+## `0.2.0`
+
+* Migrate from separate repo
+
+## `0.1.0`
 
 * Initial release

--- a/packages/run-script/package.json
+++ b/packages/run-script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octorelease/run-script",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "GitHub action to run scripts in Octorelease context.",
   "main": "lib/index.js",
   "files": [
@@ -32,10 +32,10 @@
     "@actions/core": "^1.8.2",
     "@actions/exec": "^1.1.0",
     "@actions/github": "^5.0.3",
-    "@octorelease/core": "^0.2.0",
-    "@octorelease/git": "^0.2.0",
-    "@octorelease/lerna": "^0.2.0",
-    "@octorelease/npm": "^0.2.0",
+    "@octorelease/core": "^1.0.0",
+    "@octorelease/git": "^1.0.0",
+    "@octorelease/lerna": "^1.0.0",
+    "@octorelease/npm": "^1.0.0",
     "adm-zip": "^0.5.10",
     "java-properties": "^1.0.2",
     "pluralize": "^8.0.0",

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## `1.0.0`
+
+* First stable release
+
 ## `0.1.0`
 
 * Initial release

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octorelease/vsce",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Octorelease plugin to perform actions related to VS Code extensions.",
   "main": "lib/index.js",
   "files": [
@@ -40,6 +40,6 @@
     "@actions/exec": "^1.1.0"
   },
   "peerDependencies": {
-    "@octorelease/core": "^0.2.0"
+    "@octorelease/core": "^1.0.0"
   }
 }


### PR DESCRIPTION
Now that Octorelease has been adopted across Zowe CLI and Zowe Explorer repos, it is mature enough for v1 🎉

After merging this PR, we can create `v1.0.0` and `v1` tags on the repo that we'll be able to use in workflows.