### PR TITLE
Fix formatting of "release failed" comment

### DIFF
--- a/dist/github.js
+++ b/dist/github.js
@@ -24416,7 +24416,9 @@ function fail_default(context, config) {
         body: `Release failed for the \`${context.branch.name}\` branch. :cry:
 
 \`\`\`
-` + ((_a = context.failError) == null ? void 0 : _a.stack) + `\`\`\`
+` + ((_a = context.failError) == null ? void 0 : _a.stack) + `
+\`\`\`
+
 Check the [workflow run](${workflowRunUrl}) for more error details.
 
 <sub>Powered by Octorelease :rocket:</sub>`

--- a/packages/github/src/fail.ts
+++ b/packages/github/src/fail.ts
@@ -50,7 +50,7 @@ export default async function (context: IContext, config: IPluginConfig): Promis
             ...context.ci.repo,
             issue_number: prNumber,
             body: `Release failed for the \`${context.branch.name}\` branch. :cry:\n\n` +
-                "```\n" + context.failError?.stack + "```\n" +
+                "```\n" + context.failError?.stack + "\n```\n\n" +
                 `Check the [workflow run](${workflowRunUrl}) for more error details.\n\n` +
                 `<sub>Powered by Octorelease :rocket:</sub>`
         });


### PR DESCRIPTION
The last 2 lines should be outside of the code block:
![image](https://github.com/zowe-actions/octorelease/assets/22344007/04108e21-5fea-48aa-b26a-f1f62f8ede45)
