### PR TITLE
Change default prerelease name to be channel

### DIFF
--- a/dist/core.js
+++ b/dist/core.js
@@ -20754,7 +20754,7 @@ function buildVersionInfo(branch, tagPrefix) {
     const oldVersion = cmdOutput.exitCode === 0 && cmdOutput.stdout.trim().slice(tagPrefix.length) || "0.0.0";
     let prerelease = void 0;
     if (branch.prerelease) {
-      const prereleaseName = typeof branch.prerelease === "string" ? branch.prerelease : branch.name;
+      const prereleaseName = typeof branch.prerelease === "string" ? branch.prerelease : branch.channel;
       const timestamp = (/* @__PURE__ */ new Date()).toISOString().replace(/\D/g, "").slice(0, 12);
       prerelease = `${prereleaseName}.${timestamp}`;
     }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -148,7 +148,7 @@ async function buildVersionInfo(branch: IProtectedBranch, tagPrefix: string): Pr
 
     let prerelease: string | undefined = undefined;
     if (branch.prerelease) {
-        const prereleaseName = (typeof branch.prerelease === "string") ? branch.prerelease : branch.name;
+        const prereleaseName = (typeof branch.prerelease === "string") ? branch.prerelease : branch.channel;
         const timestamp = (new Date()).toISOString().replace(/\D/g, "").slice(0, 12);
         prerelease = `${prereleaseName}.${timestamp}`;
     }


### PR DESCRIPTION
For a project like the K8s plugin that has the following `branches` config:
```
{
    name: "main",
    channel: "next",
    level: "minor",
    prerelease: true
}
```

The package version should default to `X.Y.Z-next.<timestamp>` instead of `X.Y.Z-main.<timestamp>`