### PR TITLE
Support prerelease flag for packaging VSIXs

### DIFF
--- a/dist/vsce.js
+++ b/dist/vsce.js
@@ -1173,8 +1173,11 @@ function vscePackage(context) {
   return __async(this, null, function* () {
     var _a;
     const cmdArgs = ["vsce", "package"];
-    if (fs.existsSync(path.join((context == null ? void 0 : context.rootDir) || "", "yarn.lock"))) {
+    if (fs.existsSync(path.join(context.rootDir, "yarn.lock"))) {
       cmdArgs.push("--yarn");
+    }
+    if (context.version.prerelease != null) {
+      cmdArgs.push("--pre-release");
     }
     const cmdOutput = yield exec.getExecOutput("npx", cmdArgs);
     return (_a = cmdOutput.stdout.trim().match(/Packaged: (.*\.vsix)/)) == null ? void 0 : _a[1];

--- a/packages/vsce/src/utils.ts
+++ b/packages/vsce/src/utils.ts
@@ -48,10 +48,13 @@ export async function vsceInfo(extensionName: string): Promise<Record<string, an
     } catch { /* Do nothing */ }
 }
 
-export async function vscePackage(context?: IContext): Promise<string> {
+export async function vscePackage(context: IContext): Promise<string> {
     const cmdArgs = ["vsce", "package"];
-    if (fs.existsSync(path.join(context?.rootDir || "", "yarn.lock"))) {
+    if (fs.existsSync(path.join(context.rootDir, "yarn.lock"))) {
         cmdArgs.push("--yarn");
+    }
+    if (context.version.prerelease != null) {
+        cmdArgs.push("--pre-release");
     }
     const cmdOutput = await exec.getExecOutput("npx", cmdArgs);
     return cmdOutput.stdout.trim().match(/Packaged: (.*\.vsix)/)?.[1] as string;


### PR DESCRIPTION
Apparently the `--pre-release` flag must be passed on not just the publish command, but also the package command :
https://github.com/zowe/zowe-cli-secrets-for-kubernetes/actions/runs/6041214803/job/16508348448