### PR TITLE
Disable publish of prerelease tags to VSCE Marketplace

### DIFF
--- a/dist/vsce.js
+++ b/dist/vsce.js
@@ -1192,7 +1192,8 @@ function vscePublish(context, vsixPath) {
       cmdArgs.push("--yarn");
     }
     if (context.version.prerelease != null) {
-      cmdArgs.push("--pre-release");
+      context.logger.warn("Cannot publish version with prerelease tag to VS Code Marketplace");
+      return;
     }
     yield import_core.utils.dryRunTask(context, `npx ${cmdArgs.join(" ")}`, () => __async(this, null, function* () {
       yield exec.exec("npx", cmdArgs);

--- a/packages/vsce/src/utils.ts
+++ b/packages/vsce/src/utils.ts
@@ -68,7 +68,9 @@ export async function vscePublish(context: IContext, vsixPath?: string): Promise
         cmdArgs.push("--yarn");
     }
     if (context.version.prerelease != null) {
-        cmdArgs.push("--pre-release");
+        // VS Code Marketplace doesn't support prerelease tags: https://github.com/microsoft/vsmarketplace/issues/50
+        context.logger.warn("Cannot publish version with prerelease tag to VS Code Marketplace");
+        return;
     }
     await utils.dryRunTask(context, `npx ${cmdArgs.join(" ")}`, async () => {
         await exec.exec("npx", cmdArgs);


### PR DESCRIPTION
The VS Code Marketplace doesn't support publishing versions with prerelease tags - see https://github.com/microsoft/vsmarketplace/issues/50 and https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions

We still want to package a prerelease VSIX as a GitHub release artifact and (if possible) publish it to the Open VSX Registry. Until the VSCE Marketplace fully supports semver, we can skip publishing to it when a prerelease tag is present and display a warning instead.