### PR TITLE
Don't add VSCE to released packages list when publish is skipped

### DIFF
--- a/dist/vsce.js
+++ b/dist/vsce.js
@@ -1192,8 +1192,7 @@ function vscePublish(context, vsixPath) {
       cmdArgs.push("--yarn");
     }
     if (context.version.prerelease != null) {
-      context.logger.warn("Cannot publish version with prerelease tag to VS Code Marketplace");
-      return;
+      cmdArgs.push("--pre-release");
     }
     yield import_core.utils.dryRunTask(context, `npx ${cmdArgs.join(" ")}`, () => __async(this, null, function* () {
       yield exec.exec("npx", cmdArgs);
@@ -1252,7 +1251,9 @@ function publish_default(context, config) {
     }
     if (config.vscePublish !== false) {
       const vsceMetadata = (yield vsceInfo(extensionName)) || {};
-      if (!((_a = vsceMetadata.versions) == null ? void 0 : _a.find((obj) => obj.version === packageJson.version))) {
+      if (context.version.prerelease != null) {
+        context.logger.warn("Cannot publish version with prerelease tag to VS Code Marketplace");
+      } else if (!((_a = vsceMetadata.versions) == null ? void 0 : _a.find((obj) => obj.version === packageJson.version))) {
         yield vscePublish(context, vsixPath);
         context.releasedPackages.vsce = [
           ...context.releasedPackages.vsce || [],

--- a/packages/vsce/src/publish.ts
+++ b/packages/vsce/src/publish.ts
@@ -39,7 +39,10 @@ export default async function (context: IContext, config: IPluginConfig): Promis
 
     if (config.vscePublish !== false) {
         const vsceMetadata = await utils.vsceInfo(extensionName) || {};
-        if (!vsceMetadata.versions?.find((obj: any) => obj.version === packageJson.version)) {
+        if (context.version.prerelease != null) {
+            // VSCE Marketplace doesn't support prerelease tags: https://github.com/microsoft/vsmarketplace/issues/50
+            context.logger.warn("Cannot publish version with prerelease tag to VS Code Marketplace");
+        } else if (!vsceMetadata.versions?.find((obj: any) => obj.version === packageJson.version)) {
             await utils.vscePublish(context, vsixPath);
 
             context.releasedPackages.vsce = [

--- a/packages/vsce/src/utils.ts
+++ b/packages/vsce/src/utils.ts
@@ -68,9 +68,7 @@ export async function vscePublish(context: IContext, vsixPath?: string): Promise
         cmdArgs.push("--yarn");
     }
     if (context.version.prerelease != null) {
-        // VS Code Marketplace doesn't support prerelease tags: https://github.com/microsoft/vsmarketplace/issues/50
-        context.logger.warn("Cannot publish version with prerelease tag to VS Code Marketplace");
-        return;
+        cmdArgs.push("--pre-release");
     }
     await utils.dryRunTask(context, `npx ${cmdArgs.join(" ")}`, async () => {
         await exec.exec("npx", cmdArgs);


### PR DESCRIPTION
Follow up to #112 - it worked but the PR comment posted after the release succeeded mentions the VSCE Marketplace even though we skipped publishing to there, so this PR fixes that 😋 

![image](https://github.com/zowe-actions/octorelease/assets/22344007/9aa13a4d-7c7b-4b61-877d-4d5bb4d0b172)
