### PR TITLE
Fix ignoreChanges setting in lerna.json being ignored by independent versioning

### DIFF
--- a/dist/lerna.js
+++ b/dist/lerna.js
@@ -5543,6 +5543,7 @@ var import_npm = require("./npm");
 var utils_exports = {};
 __export(utils_exports, {
   lernaList: () => lernaList,
+  lernaPostVersion: () => lernaPostVersion,
   lernaVersion: () => lernaVersion
 });
 var fs = __toESM(require("fs"));
@@ -5573,19 +5574,21 @@ function lernaList(onlyChanged) {
     return cmdOutput.exitCode === 0 ? JSON.parse(cmdOutput.stdout) : [];
   });
 }
-function lernaVersion(newVersion, excludeDirs) {
+function lernaVersion(newVersion) {
   return __async(this, null, function* () {
-    var _a, _b;
-    const cmdArgs = ["--exact", "--include-merged-tags", "--no-git-tag-version", "--yes"];
-    if (excludeDirs) {
-      const lernaJson = JSON.parse(fs.readFileSync("lerna.json", "utf-8"));
-      const ignorePatterns = [
-        ...((_b = (_a = lernaJson.command) == null ? void 0 : _a.publish) == null ? void 0 : _b.ignoreChanges) || [],
-        ...excludeDirs.map((dir) => dir + "/**")
-      ];
-      cmdArgs.push("--ignore-changes", ...ignorePatterns);
-    }
-    yield exec.exec(yield npxCmd(), ["lerna", "version", newVersion, ...cmdArgs]);
+    yield exec.exec(yield npxCmd(), [
+      "lerna",
+      "version",
+      newVersion,
+      "--exact",
+      "--include-merged-tags",
+      "--no-git-tag-version",
+      "--yes"
+    ]);
+  });
+}
+function lernaPostVersion() {
+  return __async(this, null, function* () {
     if (!fs.existsSync("yarn.lock") && !usePnpm) {
       yield exec.exec("npm", ["install", "--package-lock-only", "--ignore-scripts", "--no-audit"]);
     } else if (usePnpm) {
@@ -5675,6 +5678,7 @@ function version_default2(context, config) {
       return;
     }
     const changedPackageInfo = yield lernaList(true);
+    yield lernaVersion(context.version.new);
     if (config.versionIndependent != null) {
       for (const [packageDir, versionInfo] of Object.entries(context.version.overrides)) {
         const pkgInfo = changedPackageInfo.find((pkgInfo2) => path2.relative(context.rootDir, pkgInfo2.location) === packageDir);
@@ -5683,7 +5687,7 @@ function version_default2(context, config) {
         }
       }
     }
-    yield lernaVersion(context.version.new, Object.keys(context.version.overrides));
+    yield lernaPostVersion();
     context.changedFiles.push("lerna.json", "package.json");
     const lockfilePath = yield (0, import_find_up.default)(["pnpm-lock.yaml", "yarn.lock", "npm-shrinkwrap.json", "package-lock.json"]);
     if (lockfilePath != null) {

--- a/dist/lerna.js
+++ b/dist/lerna.js
@@ -5575,9 +5575,15 @@ function lernaList(onlyChanged) {
 }
 function lernaVersion(newVersion, excludeDirs) {
   return __async(this, null, function* () {
+    var _a, _b;
     const cmdArgs = ["--exact", "--include-merged-tags", "--no-git-tag-version", "--yes"];
     if (excludeDirs) {
-      cmdArgs.push("--ignore-changes", ...excludeDirs.map((dir) => dir + "/**"));
+      const lernaJson = JSON.parse(fs.readFileSync("lerna.json", "utf-8"));
+      const ignorePatterns = [
+        ...((_b = (_a = lernaJson.command) == null ? void 0 : _a.publish) == null ? void 0 : _b.ignoreChanges) || [],
+        ...excludeDirs.map((dir) => dir + "/**")
+      ];
+      cmdArgs.push("--ignore-changes", ...ignorePatterns);
     }
     yield exec.exec(yield npxCmd(), ["lerna", "version", newVersion, ...cmdArgs]);
     if (!fs.existsSync("yarn.lock") && !usePnpm) {

--- a/packages/lerna/src/utils.ts
+++ b/packages/lerna/src/utils.ts
@@ -41,18 +41,12 @@ export async function lernaList(onlyChanged?: boolean): Promise<Record<string, a
     return cmdOutput.exitCode === 0 ? JSON.parse(cmdOutput.stdout) : [];
 }
 
-export async function lernaVersion(newVersion: string, excludeDirs?: string[]): Promise<void> {
-    const cmdArgs = ["--exact", "--include-merged-tags", "--no-git-tag-version", "--yes"];
-    if (excludeDirs) {
-        const lernaJson = JSON.parse(fs.readFileSync("lerna.json", "utf-8"));
-        const ignorePatterns = [
-            ...(lernaJson.command?.publish?.ignoreChanges || []),
-            ...excludeDirs.map(dir => dir + "/**")
-        ];
-        cmdArgs.push("--ignore-changes", ...ignorePatterns);
-    }
-    await exec.exec(await npxCmd(), ["lerna", "version", newVersion, ...cmdArgs]);
-    // await exec.exec("npx", ["lerna", "version", newVersion, ...cmdArgs]);
+export async function lernaVersion(newVersion: string): Promise<void> {
+    await exec.exec(await npxCmd(), ["lerna", "version", newVersion,
+        "--exact", "--include-merged-tags", "--no-git-tag-version", "--yes"]);
+}
+
+export async function lernaPostVersion(): Promise<void> {
     if (!fs.existsSync("yarn.lock") && !usePnpm) {
         // Update subpackage versions in lockfile (requires npm@8.5 or newer)
         await exec.exec("npm", ["install", "--package-lock-only", "--ignore-scripts", "--no-audit"]);

--- a/packages/lerna/src/utils.ts
+++ b/packages/lerna/src/utils.ts
@@ -44,7 +44,12 @@ export async function lernaList(onlyChanged?: boolean): Promise<Record<string, a
 export async function lernaVersion(newVersion: string, excludeDirs?: string[]): Promise<void> {
     const cmdArgs = ["--exact", "--include-merged-tags", "--no-git-tag-version", "--yes"];
     if (excludeDirs) {
-        cmdArgs.push("--ignore-changes", ...excludeDirs.map(dir => dir + "/**"));
+        const lernaJson = JSON.parse(fs.readFileSync("lerna.json", "utf-8"));
+        const ignorePatterns = [
+            ...(lernaJson.command?.publish?.ignoreChanges || []),
+            ...excludeDirs.map(dir => dir + "/**")
+        ];
+        cmdArgs.push("--ignore-changes", ...ignorePatterns);
     }
     await exec.exec(await npxCmd(), ["lerna", "version", newVersion, ...cmdArgs]);
     // await exec.exec("npx", ["lerna", "version", newVersion, ...cmdArgs]);


### PR DESCRIPTION
~Resolves issue encountered when merging CLI PRs. The `lerna version` command was not ignoring changes to tests like it should.~

Switches the order of the `lerna version` and `npm version` commands to fix independent versioning.

```
$ npx lerna changed --include-merged-tags --all --json --toposort
...
info Looking for changed packages since v7.18.9
info ignoring diff in paths matching [ 'packages/**/__tests__/**' ]
...

$ npx lerna version 7.18.10 --exact --include-merged-tags --no-git-tag-version --yes --ignore-changes packages/imperative/**
...
info Looking for changed packages since v7.18.9
info ignoring diff in paths matching [ 'packages/imperative/**' ]
...
```