### PR TITLE
Support semver level "none" in branch config

### DIFF
--- a/dist/github.js
+++ b/dist/github.js
@@ -25093,7 +25093,7 @@ function getPrReleaseType(context, config) {
     }
     const releaseLabels = Array.isArray(config.checkPrLabels) ? config.checkPrLabels : DEFAULT_RELEASE_LABELS;
     let approvedLabelEvents = yield findApprovedLabelEvents(context, octokit, prNumber, releaseLabels);
-    if (approvedLabelEvents.length !== 1 && !context.dryRun) {
+    if (approvedLabelEvents.length !== 1 && !context.dryRun && context.branch.level !== "none") {
       const timeoutInMinutes = 30;
       for (const { name } of labels.data.filter((label) => releaseLabels.includes(label.name))) {
         yield octokit.rest.issues.removeLabel(__spreadProps(__spreadValues({}, context.ci.repo), {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5931,6 +5931,7 @@
       }
     },
     "packages/pypi": {
+      "name": "@octorelease/pypi",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/core/__tests__/utils.test.ts
+++ b/packages/core/__tests__/utils.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2020-2023 Zowe Actions Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IContext, SemverDiffLevels } from "../src/doc";
+import { verifyConditions } from "../src/utils";
+
+describe("Utility functions", () => {
+    const oldVersion = "1.0.0";
+
+    it("verifyConditions should append prerelease string to new version", async () => {
+        const context: Partial<IContext> = {
+            branch: { name: "main" },
+            version: {
+                old: oldVersion,
+                new: oldVersion,
+                overrides: {},
+                prerelease: "next"
+            }
+        };
+        await verifyConditions(context as IContext);
+        expect((context.version as any).new).toEqual(`${oldVersion}-next`);
+    });
+
+    it.each(SemverDiffLevels.slice(1))("verifyConditions should allow semver bumps when level is %s", async (level) => {
+        const context: Partial<IContext> = {
+            branch: {
+                name: "main",
+                level
+            },
+            version: {
+                old: oldVersion,
+                new: require("semver").inc(oldVersion, level),
+                overrides: {}
+            }
+        };
+        await expect(verifyConditions(context as IContext)).resolves.not.toThrow();
+    });
+
+    it.each(SemverDiffLevels.slice(0, -1))(
+        "verifyConditions should block semver bumps when level is %s", async (level) => {
+        const badLevel = SemverDiffLevels[SemverDiffLevels.indexOf(level) + 1];
+        const context: Partial<IContext> = {
+            branch: {
+                name: "main",
+                level
+            },
+            version: {
+                old: oldVersion,
+                new: require("semver").inc(oldVersion, badLevel),
+                overrides: {}
+            }
+        };
+        await expect(verifyConditions(context as IContext)).rejects.toThrow(
+            `Protected branch main does not allow ${badLevel} version changes`);
+    });
+});

--- a/packages/core/src/doc/IProtectedBranch.ts
+++ b/packages/core/src/doc/IProtectedBranch.ts
@@ -15,6 +15,11 @@
  */
 
 /**
+ * List of semver diff levels supported by Octorelease
+ */
+export const SemverDiffLevels = ["none", "patch", "minor", "major"];
+
+/**
  * Protected branch configuration object
  */
 export interface IProtectedBranch {
@@ -31,7 +36,7 @@ export interface IProtectedBranch {
     /**
      * Maximum semver bump level allowed
      */
-    level?: "major" | "minor" | "patch";
+    level?: typeof SemverDiffLevels[number];
 
     /**
      * Prerelease name (defaults to branch name if `true`)

--- a/packages/github/src/init.ts
+++ b/packages/github/src/init.ts
@@ -53,7 +53,7 @@ async function getPrReleaseType(context: IContext, config: IPluginConfig): Promi
     const releaseLabels = Array.isArray(config.checkPrLabels) ? config.checkPrLabels : DEFAULT_RELEASE_LABELS;
     let approvedLabelEvents = await findApprovedLabelEvents(context, octokit, prNumber, releaseLabels);
 
-    if (approvedLabelEvents.length !== 1 && !context.dryRun) {
+    if (approvedLabelEvents.length !== 1 && !context.dryRun && context.branch.level !== "none") {
         const timeoutInMinutes = 30;
 
         // Remove unapproved release labels


### PR DESCRIPTION
Resolves #126 

* Allows `"level": "none"` to be defined in release config for branches that should not allow any version bumps. This is useful for prerelease branches where we want to only change the timestamp (not the "X.Y.Z" digits) for new releases.
* Skips commenting on GitHub PRs for when semver level is none because there is only 1 valid option