### PR TITLE
Fix wrong independent version on first time publish

### DIFF
--- a/dist/core.js
+++ b/dist/core.js
@@ -22382,14 +22382,14 @@ function verifyConditions(context) {
       context.version.new = `${context.version.new.split("-")[0]}-${context.version.prerelease}`;
     }
     const semver = require_semver2();
-    const semverLevel = semver.diff(context.version.old.split("-")[0], context.version.new.split("-")[0]);
+    const semverLevel = context.version.old !== "0.0.0" ? semver.diff(context.version.old.split("-")[0], context.version.new.split("-")[0]) : null;
     for (const versionInfo of Object.values(context.version.overrides)) {
-      versionInfo.new = semver.inc(versionInfo.old.split("-")[0], semverLevel);
+      versionInfo.new = semverLevel != null ? semver.inc(versionInfo.old.split("-")[0], semverLevel) : versionInfo.old;
       if (versionInfo.prerelease != null) {
         versionInfo.new = `${versionInfo.new}-${versionInfo.prerelease}`;
       }
     }
-    if (semverLevel != null && context.branch.level != null && context.version.old != "0.0.0" && SemverDiffLevels.indexOf(semverLevel) > SemverDiffLevels.indexOf(context.branch.level)) {
+    if (semverLevel != null && context.branch.level != null && SemverDiffLevels.indexOf(semverLevel) > SemverDiffLevels.indexOf(context.branch.level)) {
       throw new Error(`Protected branch ${context.branch.name} does not allow ${semverLevel} version changes`);
     }
   });

--- a/dist/github.js
+++ b/dist/github.js
@@ -25072,7 +25072,8 @@ function init_default(context, config) {
     }
     if (config.checkPrLabels && import_core.Inputs.newVersion == null) {
       const releaseType = yield getPrReleaseType(context, config);
-      const oldVersion = (context.version.new || context.version.old).split("-")[0];
+      context.version.old = context.version.new || context.version.old;
+      const oldVersion = context.version.old.split("-")[0];
       context.version.new = releaseType != null ? require_semver2().inc(oldVersion, releaseType) : oldVersion;
     }
   });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -129,15 +129,17 @@ export async function verifyConditions(context: IContext): Promise<void> {
     }
 
     const semver = require("semver");
-    const semverLevel = semver.diff(context.version.old.split("-")[0], context.version.new.split("-")[0]);
+    const semverLevel = context.version.old !== "0.0.0" ?
+        semver.diff(context.version.old.split("-")[0], context.version.new.split("-")[0]) : null;
     for (const versionInfo of Object.values(context.version.overrides)) {
-        versionInfo.new = semver.inc(versionInfo.old.split("-")[0], semverLevel);
+        versionInfo.new = semverLevel != null ?
+            semver.inc(versionInfo.old.split("-")[0], semverLevel) : versionInfo.old;
         if (versionInfo.prerelease != null) {
             versionInfo.new = `${versionInfo.new}-${versionInfo.prerelease}`;
         }
     }
 
-    if (semverLevel != null && context.branch.level != null && context.version.old != "0.0.0" &&
+    if (semverLevel != null && context.branch.level != null &&
         SemverDiffLevels.indexOf(semverLevel) > SemverDiffLevels.indexOf(context.branch.level)) {
         throw new Error(`Protected branch ${context.branch.name} does not allow ${semverLevel} version changes`);
     }

--- a/packages/github/src/init.ts
+++ b/packages/github/src/init.ts
@@ -29,7 +29,8 @@ export default async function (context: IContext, config: IPluginConfig): Promis
 
     if (config.checkPrLabels && Inputs.newVersion == null) {
         const releaseType = await getPrReleaseType(context, config);
-        const oldVersion = (context.version.new || context.version.old).split("-")[0];
+        context.version.old = context.version.new || context.version.old;
+        const oldVersion = context.version.old.split("-")[0];
         context.version.new = releaseType != null ? require("semver").inc(oldVersion, releaseType) : oldVersion;
     }
 }


### PR DESCRIPTION
Follow up for #128 to fix the version bump from 2.3.2 to 3.0.0 on the CICS VSCE in https://github.com/zowe/cics-for-zowe-client/commit/17f8b88232eb214f290291c9e2f91504bb271007