### PR TITLE
Allow for `NPM_CONFIG_` properties

### DIFF
--- a/dist/npm.js
+++ b/dist/npm.js
@@ -1556,13 +1556,13 @@ function npmPack(inDir) {
     return cmdOutput.stdout.trim().split(/\s+/).pop();
   });
 }
-function npmPublish(context, tag, registry, inDir) {
+function npmPublish(context, options) {
   return __async(this, null, function* () {
-    const cmdArgs = ["publish", "--tag", tag, "--registry", registry];
+    const cmdArgs = ["publish", "--tag", options.tag].concat(options.registry ? ["--registry", options.registry] : []);
     if (context.dryRun) {
       cmdArgs.push("--dry-run");
     }
-    yield exec.exec("npm", cmdArgs, { cwd: inDir });
+    yield exec.exec("npm", cmdArgs, { cwd: options.inDir });
   });
 }
 function npmVersion(newVersion, inDir) {
@@ -1638,7 +1638,7 @@ var path2 = __toESM(require("path"));
 var exec3 = __toESM(require_exec());
 function publish_default(context, config, inDir) {
   return __async(this, null, function* () {
-    var _a, _b;
+    var _a, _b, _c;
     const cwd = inDir || process.cwd();
     const packageJson = JSON.parse(fs3.readFileSync(path2.join(cwd, "package.json"), "utf-8"));
     if (config.pruneShrinkwrap) {
@@ -1666,7 +1666,11 @@ function publish_default(context, config, inDir) {
       const packageTag = context.branch.channel;
       const publishedVersions = yield npmView(packageJson.name, npmRegistry, "versions");
       if (!(publishedVersions == null ? void 0 : publishedVersions.includes(packageJson.version))) {
-        yield npmPublish(context, packageTag, npmRegistry, inDir);
+        if ((_b = packageJson.publishConfig) == null ? void 0 : _b.scope) {
+          yield npmPublish(context, { tag: packageTag, inDir });
+        } else {
+          yield npmPublish(context, { tag: packageTag, registry: npmRegistry, inDir });
+        }
         context.releasedPackages.npm = [
           ...context.releasedPackages.npm || [],
           {
@@ -1679,7 +1683,7 @@ function publish_default(context, config, inDir) {
         context.logger.error(`Version ${packageJson.version} has already been published to NPM`);
       }
       const aliasTags = [];
-      if (((_b = config.aliasTags) == null ? void 0 : _b[packageTag]) != null) {
+      if (((_c = config.aliasTags) == null ? void 0 : _c[packageTag]) != null) {
         const aliasTagOrTags = config.aliasTags[packageTag];
         aliasTags.push(...typeof aliasTagOrTags === "string" ? [aliasTagOrTags] : aliasTagOrTags);
       }

--- a/dist/npm.js
+++ b/dist/npm.js
@@ -1553,7 +1553,7 @@ function npmInstall(pkgSpec, registry, inDir) {
 function npmPack(pkgSpec, registry, inDir) {
   return __async(this, null, function* () {
     const registryPrefix = pkgSpec.startsWith("@") ? `${pkgSpec.split("/")[0]}:` : "";
-    const cmdArgs = ["pack", `${pkgSpec}`, "--json", `--${registryPrefix}registry=${registry}`];
+    const cmdArgs = ["pack", `--${registryPrefix}registry=${registry}`];
     const cmdOutput = yield exec.getExecOutput("npm", cmdArgs, { cwd: inDir });
     return cmdOutput.stdout.trim().split(/\s+/).pop();
   });

--- a/dist/npm.js
+++ b/dist/npm.js
@@ -1561,8 +1561,7 @@ function npmPack(pkgSpec, registry, inDir) {
 function npmPublish(context, options) {
   return __async(this, null, function* () {
     const registryPrefix = options.pkgSpec.startsWith("@") ? `${options.pkgSpec.split("/")[0]}:` : "";
-    const registryArgs = [`${options.pkgSpec}`, "--json", `--${registryPrefix}registry=${options.registry}`];
-    const cmdArgs = ["publish", "--tag", options.tag, ...registryArgs];
+    const cmdArgs = ["publish", "--tag", options.tag, `--${registryPrefix}registry=${options.registry}`];
     if (context.dryRun) {
       cmdArgs.push("--dry-run");
     }

--- a/dist/run-script.js
+++ b/dist/run-script.js
@@ -3675,7 +3675,7 @@ function updateDependency(context3, pkgName, pkgTag, dev) {
     var _a;
     let tempPkgTag = "";
     let moreRgs = [];
-    const env = {};
+    const env = __spreadValues({}, process.env);
     if (!Array.isArray(pkgTag)) {
       tempPkgTag = pkgTag;
     } else {

--- a/dist/run-script.js
+++ b/dist/run-script.js
@@ -3672,14 +3672,29 @@ function getDependencies(context3, branch, dev) {
 }
 function updateDependency(context3, pkgName, pkgTag, dev) {
   return __async(this, null, function* () {
-    context3.logger.debug(`Updating ${dev ? "devD" : "d"}ependency for: ${pkgName}@${pkgTag}`);
-    const cmdOutput = (yield exec.getExecOutput("npm", ["list", pkgName, "--json", "--depth", "0"])).stdout;
+    var _a;
+    let tempPkgTag = "";
+    let moreRgs = [];
+    const env = {};
+    if (!Array.isArray(pkgTag)) {
+      tempPkgTag = pkgTag;
+    } else {
+      tempPkgTag = (_a = pkgTag.shift()) != null ? _a : "";
+      moreRgs = pkgTag;
+      for (const reg of moreRgs) {
+        const propKey = "NPM_CONFIG_" + reg.split("=")[0].toUpperCase();
+        env[propKey] = reg.split("=")[1];
+      }
+    }
+    context3.logger.debug(`Updating ${dev ? "devD" : "d"}ependency for: ${pkgName}@${tempPkgTag}`);
+    const cmdOutput = (yield exec.getExecOutput("npm", ["list", pkgName, "--json", "--depth", "0"], { env })).stdout;
     const currentVersion = JSON.parse(cmdOutput).dependencies[pkgName].version;
     if (resolutions[pkgName] == null) {
-      context3.logger.debug(`Gathering version information for: ${pkgName}@${pkgTag}`);
+      context3.logger.debug(`Gathering version information for: ${pkgName}@${tempPkgTag}`);
       resolutions[pkgName] = (yield exec.getExecOutput(
         "npm",
-        ["view", `${pkgName}@${pkgTag}`, "version"]
+        ["view", `${pkgName}@${tempPkgTag}`, "version"],
+        { env }
       )).stdout.trim();
     }
     const latestVersion = resolutions[pkgName];
@@ -3687,7 +3702,7 @@ function updateDependency(context3, pkgName, pkgTag, dev) {
       const npmArgs = dev ? ["--save-dev"] : ["--save-prod", "--save-exact"];
       const newUpdate = `${pkgName}: ${currentVersion} -> ${latestVersion}`;
       context3.logger.debug(`Updating ${newUpdate}`);
-      yield exec.exec("npm", ["install", `${pkgName}@${latestVersion}`, ...npmArgs]);
+      yield exec.exec("npm", ["install", `${pkgName}@${latestVersion}`, ...npmArgs], { env });
       updateDetails.push(newUpdate);
     }
   });

--- a/dist/run-script.js
+++ b/dist/run-script.js
@@ -3674,14 +3674,14 @@ function updateDependency(context3, pkgName, pkgTag, dev) {
   return __async(this, null, function* () {
     var _a;
     let tempPkgTag = "";
-    let moreRgs = [];
+    let moreArgs = [];
     const env = __spreadValues({}, process.env);
     if (!Array.isArray(pkgTag)) {
       tempPkgTag = pkgTag;
     } else {
       tempPkgTag = (_a = pkgTag.shift()) != null ? _a : "";
-      moreRgs = pkgTag;
-      for (const reg of moreRgs) {
+      moreArgs = pkgTag;
+      for (const reg of moreArgs) {
         const propKey = "NPM_CONFIG_" + reg.split("=")[0].toUpperCase();
         env[propKey] = reg.split("=")[1];
       }

--- a/packages/npm/src/publish.ts
+++ b/packages/npm/src/publish.ts
@@ -56,7 +56,11 @@ export default async function (context: IContext, config: IPluginConfig, inDir?:
         // Publish package
         const publishedVersions = await utils.npmView(packageJson.name, npmRegistry, "versions");
         if (!publishedVersions?.includes(packageJson.version)) {
-            await utils.npmPublish(context, packageTag, npmRegistry, inDir);
+            if (packageJson.publishConfig?.scope) {
+                await utils.npmPublish(context, { tag: packageTag, inDir });
+            } else {
+                await utils.npmPublish(context, { tag: packageTag, registry: npmRegistry, inDir });
+            }
 
             context.releasedPackages.npm = [
                 ...(context.releasedPackages.npm || []),

--- a/packages/npm/src/utils.ts
+++ b/packages/npm/src/utils.ts
@@ -63,8 +63,7 @@ export interface INpmPublishOptions {
 }
 export async function npmPublish(context: IContext, options: INpmPublishOptions): Promise<void> {
     const registryPrefix = options.pkgSpec.startsWith("@") ? `${options.pkgSpec.split("/")[0]}:` : "";
-    const registryArgs = [`${options.pkgSpec}`, "--json", `--${registryPrefix}registry=${options.registry}`];
-    const cmdArgs = ["publish", "--tag", options.tag, ...registryArgs];
+    const cmdArgs = ["publish", "--tag", options.tag, `--${registryPrefix}registry=${options.registry}`];
     if (context.dryRun) {
         cmdArgs.push("--dry-run");
     }

--- a/packages/npm/src/utils.ts
+++ b/packages/npm/src/utils.ts
@@ -53,12 +53,18 @@ export async function npmPack(inDir?: string): Promise<string> {
     return cmdOutput.stdout.trim().split(/\s+/).pop() as string;
 }
 
-export async function npmPublish(context: IContext, tag: string, registry: string, inDir?: string): Promise<void> {
-    const cmdArgs = ["publish", "--tag", tag, "--registry", registry];
+export interface INpmPublishOptions {
+    tag: string;
+    registry?: string;
+    inDir?: string;
+}
+export async function npmPublish(context: IContext, options: INpmPublishOptions): Promise<void> {
+    const cmdArgs = ["publish", "--tag", options.tag]
+        .concat(options.registry ? ["--registry", options.registry] : []);
     if (context.dryRun) {
         cmdArgs.push("--dry-run");
     }
-    await exec.exec("npm", cmdArgs, { cwd: inDir });
+    await exec.exec("npm", cmdArgs, { cwd: options.inDir });
 }
 
 export async function npmVersion(newVersion: string, inDir?: string): Promise<void> {

--- a/packages/npm/src/utils.ts
+++ b/packages/npm/src/utils.ts
@@ -50,7 +50,7 @@ export async function npmInstall(pkgSpec: string, registry: string, inDir?: stri
 
 export async function npmPack(pkgSpec: string, registry: string, inDir?: string): Promise<string> {
     const registryPrefix = pkgSpec.startsWith("@") ? `${pkgSpec.split("/")[0]}:` : "";
-    const cmdArgs = ["pack", `${pkgSpec}`, "--json", `--${registryPrefix}registry=${registry}`];
+    const cmdArgs = ["pack", `--${registryPrefix}registry=${registry}`];
     const cmdOutput = await exec.getExecOutput("npm", cmdArgs, { cwd: inDir });
     return cmdOutput.stdout.trim().split(/\s+/).pop() as string;
 }

--- a/packages/npm/src/utils.ts
+++ b/packages/npm/src/utils.ts
@@ -48,19 +48,23 @@ export async function npmInstall(pkgSpec: string, registry: string, inDir?: stri
     await exec.exec("npm", ["install", pkgSpec, `--${registryPrefix}registry=${registry}`], { cwd: inDir });
 }
 
-export async function npmPack(inDir?: string): Promise<string> {
-    const cmdOutput = await exec.getExecOutput("npm", ["pack"], { cwd: inDir });
+export async function npmPack(pkgSpec: string, registry: string, inDir?: string): Promise<string> {
+    const registryPrefix = pkgSpec.startsWith("@") ? `${pkgSpec.split("/")[0]}:` : "";
+    const cmdArgs = ["pack", `${pkgSpec}`, "--json", `--${registryPrefix}registry=${registry}`];
+    const cmdOutput = await exec.getExecOutput("npm", cmdArgs, { cwd: inDir });
     return cmdOutput.stdout.trim().split(/\s+/).pop() as string;
 }
 
 export interface INpmPublishOptions {
     tag: string;
-    registry?: string;
+    pkgSpec: string;
+    registry: string;
     inDir?: string;
 }
 export async function npmPublish(context: IContext, options: INpmPublishOptions): Promise<void> {
-    const cmdArgs = ["publish", "--tag", options.tag]
-        .concat(options.registry ? ["--registry", options.registry] : []);
+    const registryPrefix = options.pkgSpec.startsWith("@") ? `${options.pkgSpec.split("/")[0]}:` : "";
+    const registryArgs = [`${options.pkgSpec}`, "--json", `--${registryPrefix}registry=${options.registry}`];
+    const cmdArgs = ["publish", "--tag", options.tag, ...registryArgs];
     if (context.dryRun) {
         cmdArgs.push("--dry-run");
     }

--- a/packages/run-script/scripts/npmUpdate.ts
+++ b/packages/run-script/scripts/npmUpdate.ts
@@ -44,16 +44,21 @@ function getDependencies(context: IContext, branch: IProtectedBranchWithDeps, de
     return dependencyMap;
 }
 
-async function updateDependency(context: IContext, pkgName: string, pkgTag: string | string[], dev: boolean): Promise<void> {
+async function updateDependency(
+    context: IContext,
+    pkgName: string,
+    pkgTag: string | string[],
+    dev: boolean
+): Promise<void> {
     let tempPkgTag = "";
-    let moreRgs: string[] = [];
+    let moreArgs: string[] = [];
     const env: { [key: string]: string } = { ...process.env as any } // ?
     if (!Array.isArray(pkgTag)) {
         tempPkgTag = pkgTag;
     } else {
         tempPkgTag = pkgTag.shift() ?? "";
-        moreRgs = pkgTag;
-        for (const reg of moreRgs) {
+        moreArgs = pkgTag;
+        for (const reg of moreArgs) {
             const propKey = "NPM_CONFIG_" + reg.split("=")[0].toUpperCase();
             env[propKey] = reg.split("=")[1];
         }

--- a/packages/run-script/scripts/npmUpdate.ts
+++ b/packages/run-script/scripts/npmUpdate.ts
@@ -25,8 +25,8 @@ const updateDetails: string[] = [];
 let resolutions: Record<string, string> = {};
 
 interface IProtectedBranchWithDeps extends IProtectedBranch {
-    dependencies: string[] | Record<string, string>;
-    devDependencies: string[] | Record<string, string>;
+    dependencies: string[] | Record<string, string | string[]>;
+    devDependencies: string[] | Record<string, string | string[]>;
 }
 
 function getDependencies(context: IContext, branch: IProtectedBranchWithDeps, dev: boolean) {
@@ -47,8 +47,8 @@ function getDependencies(context: IContext, branch: IProtectedBranchWithDeps, de
 async function updateDependency(context: IContext, pkgName: string, pkgTag: string | string[], dev: boolean): Promise<void> {
     let tempPkgTag = "";
     let moreRgs: string[] = [];
-    const env: {[key: string]: string} = {}; // { ... process.env } // ?
-    if( typeof pkgTag === "string") {
+    const env: { [key: string]: string } = {}; // { ... process.env } // ?
+    if (typeof pkgTag === "string") {
         tempPkgTag = pkgTag;
     } else {
         tempPkgTag = pkgTag.shift() ?? "";

--- a/packages/run-script/scripts/npmUpdate.ts
+++ b/packages/run-script/scripts/npmUpdate.ts
@@ -48,7 +48,7 @@ async function updateDependency(context: IContext, pkgName: string, pkgTag: stri
     let tempPkgTag = "";
     let moreRgs: string[] = [];
     const env: { [key: string]: string } = {}; // { ... process.env } // ?
-    if (typeof pkgTag === "string") {
+    if (!Array.isArray(pkgTag)) {
         tempPkgTag = pkgTag;
     } else {
         tempPkgTag = pkgTag.shift() ?? "";

--- a/packages/run-script/scripts/npmUpdate.ts
+++ b/packages/run-script/scripts/npmUpdate.ts
@@ -47,7 +47,7 @@ function getDependencies(context: IContext, branch: IProtectedBranchWithDeps, de
 async function updateDependency(context: IContext, pkgName: string, pkgTag: string | string[], dev: boolean): Promise<void> {
     let tempPkgTag = "";
     let moreRgs: string[] = [];
-    const env: { [key: string]: string } = {}; // { ... process.env } // ?
+    const env: { [key: string]: string } = { ...process.env as any } // ?
     if (!Array.isArray(pkgTag)) {
         tempPkgTag = pkgTag;
     } else {


### PR DESCRIPTION
Before
![image](https://github.com/zowe-actions/octorelease/assets/37381190/860e14f0-e2a7-4aa2-aae6-e5857ecbbb7a)

After
![image](https://github.com/zowe-actions/octorelease/assets/37381190/83a47e64-99bf-447d-b0fb-1bc1d9a62d55)
`    (with lots of bad engine errors due to old non-vulnerable transitive dependencies) `
![image](https://github.com/zowe-actions/octorelease/assets/37381190/5bc61f56-1524-4a83-8283-970896009866)

---

Here is a failing build
https://github.com/zowe/cics-for-zowe-client/actions/runs/7789736270

And here is a passing one
https://github.com/zowe/cics-for-zowe-client/actions/runs/7791773212/job/21248520867?pr=92
 