### PR TITLE
Don't update prerelease version if new-version input is set

### DIFF
--- a/dist/core.js
+++ b/dist/core.js
@@ -22377,8 +22377,9 @@ function loadPlugins(context) {
 }
 function verifyConditions(context) {
   return __async(this, null, function* () {
-    context.version.new = Inputs.newVersion || context.version.new;
-    if (context.version.prerelease != null) {
+    if (Inputs.newVersion != null) {
+      context.version.new = Inputs.newVersion;
+    } else if (context.version.prerelease != null) {
       context.version.new = `${context.version.new.split("-")[0]}-${context.version.prerelease}`;
     }
     const semver = require_semver2();

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -123,8 +123,9 @@ export async function loadPlugins(context: IContext): Promise<IPluginsLoaded> {
  * @param context Global context object for Octorelease
  */
 export async function verifyConditions(context: IContext): Promise<void> {
-    context.version.new = Inputs.newVersion || context.version.new;
-    if (context.version.prerelease != null) {
+    if (Inputs.newVersion != null) {
+        context.version.new = Inputs.newVersion;
+    } else if (context.version.prerelease != null) {
         context.version.new = `${context.version.new.split("-")[0]}-${context.version.prerelease}`;
     }
 


### PR DESCRIPTION
This should prevent the weird tag/release that was created on the Zowe Python SDK repo 😋 
https://github.com/zowe/zowe-client-python-sdk/releases/tag/v1.0.0-undefined.202403131940

Since the Python SDK sets a manual version with the `new-version` input, Octorelease should not change this version at all.