### PR TITLE
Fix lerna bumping too many package versions

### DIFF
--- a/dist/lerna.js
+++ b/dist/lerna.js
@@ -5585,17 +5585,13 @@ function lernaList(onlyChanged) {
     return cmdOutput.exitCode === 0 ? JSON.parse(cmdOutput.stdout) : [];
   });
 }
-function lernaVersion(newVersion) {
+function lernaVersion(newVersion, excludeDirs) {
   return __async(this, null, function* () {
-    yield exec.exec(yield npxCmd(), [
-      "lerna",
-      "version",
-      newVersion,
-      "--exact",
-      "--include-merged-tags",
-      "--no-git-tag-version",
-      "--yes"
-    ]);
+    const cmdArgs = ["--exact", "--include-merged-tags", "--no-git-tag-version", "--yes"];
+    if (excludeDirs) {
+      cmdArgs.push("--ignore-changes", ...excludeDirs.map((dir) => dir + "/**"));
+    }
+    yield exec.exec(yield npxCmd(), ["lerna", "version", newVersion, ...cmdArgs]);
   });
 }
 function lernaPostVersion() {
@@ -5703,7 +5699,7 @@ function version_default2(context, config) {
       return;
     }
     const changedPackageInfo = yield lernaList(true);
-    yield lernaVersion(context.version.new);
+    yield lernaVersion(context.version.new, Object.keys(context.version.overrides));
     if (config.versionIndependent != null) {
       for (const [packageDir, versionInfo] of Object.entries(context.version.overrides)) {
         const pkgInfo = changedPackageInfo.find((pkgInfo2) => path2.relative(context.rootDir, pkgInfo2.location) === packageDir);

--- a/packages/lerna/src/utils.ts
+++ b/packages/lerna/src/utils.ts
@@ -47,9 +47,12 @@ export async function lernaList(onlyChanged?: boolean): Promise<Record<string, a
     return cmdOutput.exitCode === 0 ? JSON.parse(cmdOutput.stdout) : [];
 }
 
-export async function lernaVersion(newVersion: string): Promise<void> {
-    await exec.exec(await npxCmd(), ["lerna", "version", newVersion,
-        "--exact", "--include-merged-tags", "--no-git-tag-version", "--yes"]);
+export async function lernaVersion(newVersion: string, excludeDirs?: string[]): Promise<void> {
+    const cmdArgs = ["--exact", "--include-merged-tags", "--no-git-tag-version", "--yes"];
+    if (excludeDirs) {
+        cmdArgs.push("--ignore-changes", ...excludeDirs.map(dir => dir + "/**"));
+    }
+    await exec.exec(await npxCmd(), ["lerna", "version", newVersion, ...cmdArgs]);
 }
 
 export async function lernaPostVersion(): Promise<void> {

--- a/packages/lerna/src/version.ts
+++ b/packages/lerna/src/version.ts
@@ -30,7 +30,7 @@ export default async function (context: IContext, config: IPluginConfig): Promis
     }
 
     const changedPackageInfo = await utils.lernaList(true);
-    await utils.lernaVersion(context.version.new);
+    await utils.lernaVersion(context.version.new, Object.keys(context.version.overrides));
     if (config.versionIndependent != null) {
         // Lerna's ignoreChanges option doesn't behave the way we want. Even if
         // we tell it to ignore a package directory, it will still bump that


### PR DESCRIPTION
Fixes regression introduced in #121 - we need to specify `--ignore-changes` on the lerna version command.

Example of deployment workflow behaving incorrectly in the zowe/cics-for-zowe-client repo:
https://github.com/zowe/cics-for-zowe-client/actions/runs/8947499191/job/24579578134

Even though lerna detected that only the VSCE had changed, it bumped the version number on all packages. This happens because the `lerna version` command has logic that assumes a major version bump on one package requires a version bump across all the rest.

**How to Test**

To test that CICS versioning works with the new command:
<sub>should bump nothing because only VSCE changed which is versioned independently</sub>
```
git clone https://github.com/zowe/cics-for-zowe-client.git
cd cics-for-zowe-client
git checkout f5c29c60917e68c5a7780176a44b7b7be23566a2
npm ci
echo '{"version": "5.0.5", "useWorkspaces": true}' > lerna.json
npx lerna version 5.0.6 --exact --include-merged-tags --no-git-tag-version --yes --ignore-changes "packages/vsce/**"
```

To test that CLI versioning still works:
<sub>should bump everything because Imperative changed which is depended on by all the other packages</sub>
```
git clone https://github.com/zowe/zowe-cli.git
cd zowe-cli
git checkout 62a9b14ba8b0522788d2977ab77414063d78cd71
npm ci
cat lerna.json
npx lerna version 7.18.11 --exact --include-merged-tags --no-git-tag-version --yes --ignore-changes "packages/imperative/**"
```