### PR TITLE
Make OVSX publish optional since it is flaky

### DIFF
--- a/dist/github.js
+++ b/dist/github.js
@@ -25283,10 +25283,11 @@ function success_default(context, config) {
         packageList.push(`**${pkgType}**: ${pkgName}`);
       }
     }
+    const releaseMessage = packageList.some((line) => line.includes("\u274C")) ? `Release succeeded for the \`${context.branch.name}\` branch with some errors. :warning:` : `Release succeeded for the \`${context.branch.name}\` branch. :tada:`;
     yield import_core3.utils.dryRunTask(context, "create success comment on pull request", () => __async(this, null, function* () {
       yield octokit.rest.issues.createComment(__spreadProps(__spreadValues({}, context.ci.repo), {
         issue_number: prNumber,
-        body: `Release succeeded for the \`${context.branch.name}\` branch. :tada:
+        body: `${releaseMessage}
 
 The following packages have been published:
 ` + packageList.map((line) => `* ${line}`).join("\n") + `

--- a/dist/vsce.js
+++ b/dist/vsce.js
@@ -1289,7 +1289,8 @@ function publish_default(context, config) {
         let success = true;
         try {
           yield ovsxPublish(context, vsixPath);
-        } catch (e) {
+        } catch (err) {
+          context.logger.error(err.toString());
           success = false;
         }
         context.releasedPackages.vsce = [

--- a/dist/vsce.js
+++ b/dist/vsce.js
@@ -1286,13 +1286,18 @@ function publish_default(context, config) {
     if (config.ovsxPublish) {
       const ovsxMetadata = (yield ovsxInfo(extensionName)) || {};
       if (!Object.keys(ovsxMetadata.allVersions || {}).includes(packageJson.version)) {
-        yield ovsxPublish(context, vsixPath);
+        let success = true;
+        try {
+          yield ovsxPublish(context, vsixPath);
+        } catch (e) {
+          success = false;
+        }
         context.releasedPackages.vsce = [
           ...context.releasedPackages.vsce || [],
-          {
+          success ? {
             name: `${extensionName}@${packageJson.version} (OVSX)`,
             url: `https://open-vsx.org/extension/${extensionName.replace(".", "/")}/${packageJson.version}`
-          }
+          } : { name: `\u274C ${extensionName}@${packageJson.version} (OVSX)` }
         ];
       } else {
         context.logger.error(`Version ${packageJson.version} has already been published to Open VSX Registry`);

--- a/packages/github/src/success.ts
+++ b/packages/github/src/success.ts
@@ -44,11 +44,14 @@ export default async function (context: IContext, config: IPluginConfig): Promis
             packageList.push(`**${pkgType}**: ${pkgName}`);
         }
     }
+    const releaseMessage = packageList.some(line => line.includes("❌")) ?
+        `Release succeeded for the \`${context.branch.name}\` branch with some errors. :warning:` :
+        `Release succeeded for the \`${context.branch.name}\` branch. :tada:`;
     await coreUtils.dryRunTask(context, "create success comment on pull request", async () => {
         await octokit.rest.issues.createComment({
             ...context.ci.repo,
             issue_number: prNumber,
-            body: `Release succeeded for the \`${context.branch.name}\` branch. :tada:\n\n` +
+            body: `${releaseMessage}\n\n` +
                 `The following packages have been published:\n` +
                 packageList.map(line => `* ${line}`).join("\n") + `\n\n` +
                 `<sub>Powered by Octorelease :rocket:</sub>`

--- a/packages/vsce/src/publish.ts
+++ b/packages/vsce/src/publish.ts
@@ -60,14 +60,19 @@ export default async function (context: IContext, config: IPluginConfig): Promis
     if (config.ovsxPublish) {
         const ovsxMetadata = await utils.ovsxInfo(extensionName) || {};
         if (!Object.keys(ovsxMetadata.allVersions || {}).includes(packageJson.version)) {
-            await utils.ovsxPublish(context, vsixPath);
+            let success = true;
+            try {
+                await utils.ovsxPublish(context, vsixPath);
+            } catch {
+                success = false;
+            }
 
             context.releasedPackages.vsce = [
                 ...(context.releasedPackages.vsce || []),
-                {
+                success ? {
                     name: `${extensionName}@${packageJson.version} (OVSX)`,
                     url: `https://open-vsx.org/extension/${extensionName.replace(".", "/")}/${packageJson.version}`
-                }
+                } : { name: `❌ ${extensionName}@${packageJson.version} (OVSX)` }
             ];
         } else {
             context.logger.error(`Version ${packageJson.version} has already been published to Open VSX Registry`);

--- a/packages/vsce/src/publish.ts
+++ b/packages/vsce/src/publish.ts
@@ -63,7 +63,8 @@ export default async function (context: IContext, config: IPluginConfig): Promis
             let success = true;
             try {
                 await utils.ovsxPublish(context, vsixPath);
-            } catch {
+            } catch (err) {
+                context.logger.error((err as any).toString());
                 success = false;
             }
 


### PR DESCRIPTION
Fixes the Zowe Explorer deployment until https://github.com/eclipse/openvsx/issues/920 is resolved