### PR TITLE
Fix spurious changelog update for release-current

### DIFF
--- a/dist/changelog.js
+++ b/dist/changelog.js
@@ -4212,7 +4212,7 @@ function updatePackageChangelog(context, changelogFile, headerLine) {
   if (fs.existsSync(changelogFile)) {
     const oldContents = fs.readFileSync(changelogFile, "utf-8");
     const newVersion = ((_a = context.version.overrides[path.dirname(changelogFile)]) == null ? void 0 : _a.new) || context.version.new;
-    if (oldContents.includes(`## \`${newVersion}\``)) {
+    if (oldContents.includes(`## \`${newVersion}\``) || context.version.old === newVersion) {
       return false;
     }
     const newContents = oldContents.replace(headerLine, `## \`${newVersion}\``);

--- a/packages/changelog/src/version.ts
+++ b/packages/changelog/src/version.ts
@@ -91,7 +91,7 @@ function updatePackageChangelog(context: IContext, changelogFile: string, header
     if (fs.existsSync(changelogFile)) {
         const oldContents = fs.readFileSync(changelogFile, "utf-8");
         const newVersion = context.version.overrides[path.dirname(changelogFile)]?.new || context.version.new;
-        if (oldContents.includes(`## \`${newVersion}\``)) {
+        if (oldContents.includes(`## \`${newVersion}\``) || context.version.old === newVersion) {
             return false;
         }
 


### PR DESCRIPTION
Fixes regression introduced in #129 to prevent spurious commits like [this one](https://github.com/zowe/zowe-cli/commit/c9b153b1e7086a988de2cf9b87f54516c5108d9a) - thanks @awharn for reporting the issue 😋 