### PR TITLE
Allow prereleases without a version suffix

### DIFF
--- a/dist/core.js
+++ b/dist/core.js
@@ -34937,14 +34937,14 @@ async function loadPlugins(context) {
 async function verifyConditions(context) {
   if (Inputs.newVersion != null) {
     context.version.new = Inputs.newVersion;
-  } else if (context.version.prerelease != null) {
+  } else if (context.version.prerelease) {
     context.version.new = `${context.version.new.split("-")[0]}-${context.version.prerelease}`;
   }
   const semver = require_semver2();
   const semverLevel = context.version.old !== "0.0.0" ? semver.diff(context.version.old.split("-")[0], context.version.new.split("-")[0]) : null;
   for (const versionInfo of Object.values(context.version.overrides)) {
     versionInfo.new = semverLevel != null ? semver.inc(versionInfo.old.split("-")[0], semverLevel) : versionInfo.old.split("-")[0];
-    if (versionInfo.prerelease != null) {
+    if (versionInfo.prerelease) {
       versionInfo.new = `${versionInfo.new}-${versionInfo.prerelease}`;
     }
   }
@@ -34959,7 +34959,7 @@ async function buildVersionInfo(branch, tagPrefix) {
     { ignoreReturnCode: true }
   );
   const oldVersion = cmdOutput.exitCode === 0 && cmdOutput.stdout.trim().slice(tagPrefix.length) || "0.0.0";
-  let prerelease = void 0;
+  let prerelease = branch.prerelease === "" ? "" : void 0;
   if (branch.prerelease) {
     const prereleaseName = typeof branch.prerelease === "string" ? branch.prerelease : branch.channel;
     const timestamp = (/* @__PURE__ */ new Date()).toISOString().replace(/\D/g, "").slice(0, 12);

--- a/dist/github.js
+++ b/dist/github.js
@@ -43101,7 +43101,7 @@ async function getPrReleaseType(context, config) {
       });
     }
     const oldVersion = (context.version.new || context.version.old).split("-")[0];
-    const prereleaseSuffix = context.version.prerelease != null ? `-${context.version.prerelease}` : "";
+    const prereleaseSuffix = context.version.prerelease ? `-${context.version.prerelease}` : "";
     const semverInc = require_inc();
     let commentBody = `Version info from a repo admin is required to publish a new version. Please add one of the following labels within ${timeoutInMinutes} minutes:
 * **${releaseLabels[0]}**: \`${oldVersion}${prereleaseSuffix}\` (default)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Recent Changes
+
+* Added support for defining `prerelease` on branch config as an empty string, to allow prereleases without a version suffix
+
 ## `1.0.1`
 
 * Fixed wrong branch detected for GitHub Actions `pull_request` builds

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -125,7 +125,7 @@ export async function loadPlugins(context: IContext): Promise<IPluginsLoaded> {
 export async function verifyConditions(context: IContext): Promise<void> {
     if (Inputs.newVersion != null) {
         context.version.new = Inputs.newVersion;
-    } else if (context.version.prerelease != null) {
+    } else if (context.version.prerelease) {
         context.version.new = `${context.version.new.split("-")[0]}-${context.version.prerelease}`;
     }
 
@@ -135,7 +135,7 @@ export async function verifyConditions(context: IContext): Promise<void> {
     for (const versionInfo of Object.values(context.version.overrides)) {
         versionInfo.new = semverLevel != null ?
             semver.inc(versionInfo.old.split("-")[0], semverLevel) : versionInfo.old.split("-")[0];
-        if (versionInfo.prerelease != null) {
+        if (versionInfo.prerelease) {
             versionInfo.new = `${versionInfo.new}-${versionInfo.prerelease}`;
         }
     }
@@ -157,7 +157,7 @@ async function buildVersionInfo(branch: IProtectedBranch, tagPrefix: string): Pr
         ["describe", "--tags", "--abbrev=0", `--match=${tagPrefix}[0-9]*.[0-9]*.[0-9]*`], { ignoreReturnCode: true });
     const oldVersion = cmdOutput.exitCode === 0 && cmdOutput.stdout.trim().slice(tagPrefix.length) || "0.0.0";
 
-    let prerelease: string | undefined = undefined;
+    let prerelease: string | undefined = branch.prerelease === "" ? "" : undefined;
     if (branch.prerelease) {
         const prereleaseName = (typeof branch.prerelease === "string") ? branch.prerelease : branch.channel;
         const timestamp = (new Date()).toISOString().replace(/\D/g, "").slice(0, 12);

--- a/packages/github/src/init.ts
+++ b/packages/github/src/init.ts
@@ -68,7 +68,8 @@ async function getPrReleaseType(context: IContext, config: IPluginConfig): Promi
 
         // Comment on PR to request version approval
         const oldVersion = (context.version.new || context.version.old).split("-")[0];
-        const prereleaseSuffix = (context.version.prerelease != null) ? `-${context.version.prerelease}` : "";
+        // Check if prerelease is truthy to handle case of empty string
+        const prereleaseSuffix = context.version.prerelease ? `-${context.version.prerelease}` : "";
         const semverInc = require("semver/functions/inc");
         let commentBody = `Version info from a repo admin is required to publish a new version. ` +
             `Please add one of the following labels within ${timeoutInMinutes} minutes:\n` +


### PR DESCRIPTION
Added support for defining `prerelease` on branch config as an empty string, to allow prereleases without a version suffix.